### PR TITLE
Key Time To Live hack

### DIFF
--- a/src/CacheFrontEnd.php
+++ b/src/CacheFrontEnd.php
@@ -30,7 +30,7 @@ class CacheFrontEnd
     $key = $this->getCacheKey($latitude, $longitude);
     $this->cacheBackend->set($key, $data);
     if(method_exists ($this->cacheBackend, 'expireAt') && isset($this->TTLInSeconds)) {
-        $this->cacheBackend->expireAt($key, time() + $this->TTLInSeconds);
+        $this->cacheBackend->expireAt($key, time() + intval($this->TTLInSeconds));
     }
   }
   

--- a/src/CacheFrontEnd.php
+++ b/src/CacheFrontEnd.php
@@ -14,17 +14,24 @@ class CacheFrontEnd
   {
     $this->keySize = $keySize;
   }
-  
+
+  public function setDefaultKeyTTL($TTLInSeconds)
+  {
+    $this->TTLInSeconds = $TTLInSeconds;
+  }
+
   public function setPrefix($prefix)
   {
     $this->prefix = $prefix;
   }
-  
-  
+
   public function set($latitude,$longitude,$data)
   {
     $key = $this->getCacheKey($latitude, $longitude);
     $this->cacheBackend->set($key, $data);
+    if(method_exists ($this->cacheBackend, 'expireAt') && isset($this->TTLInSeconds)) {
+        $this->cacheBackend->expireAt($key, time() + $this->TTLInSeconds);
+    }
   }
   
   public function get($latitude,$longitude)


### PR DESCRIPTION
Support for a key default Time To Live to be set using new method setDefaultKeyTTL(). When key is set, if cacheBackend has a method named 'expireAt' it will be used to set the key expiration to the previously set default.
