### PR TITLE
Enable key TTL to be set with default value on every update

### DIFF
--- a/src/CacheFrontEnd.php
+++ b/src/CacheFrontEnd.php
@@ -29,8 +29,8 @@ class CacheFrontEnd
   {
     $key = $this->getCacheKey($latitude, $longitude);
     $this->cacheBackend->set($key, $data);
-    if(method_exists ($this->cacheBackend, 'expireAt') && isset($this->TTLInSeconds)) {
-        $this->cacheBackend->expireAt($key, time() + $this->TTLInSeconds);
+    if(method_exists($this->cacheBackend, 'expireAt') && isset($this->TTLInSeconds)) {
+        $this->cacheBackend->expireAt($key, time() + intval($this->TTLInSeconds));
     }
   }
   
@@ -39,7 +39,7 @@ class CacheFrontEnd
     $key = $this->getCacheKey($latitude, $longitude);
     return $this->cacheBackend->get($key);
   }
- 
+
   public function exists($latitude,$longitude)
   {
     $key = $this->getCacheKey($latitude, $longitude);

--- a/src/CacheFrontEnd.php
+++ b/src/CacheFrontEnd.php
@@ -14,17 +14,24 @@ class CacheFrontEnd
   {
     $this->keySize = $keySize;
   }
-  
+
+  public function setDefaultKeyTTL($TTLInSeconds)
+  {
+    $this->TTLInSeconds = $TTLInSeconds;
+  }
+
   public function setPrefix($prefix)
   {
     $this->prefix = $prefix;
   }
-  
-  
+
   public function set($latitude,$longitude,$data)
   {
     $key = $this->getCacheKey($latitude, $longitude);
     $this->cacheBackend->set($key, $data);
+    if(method_exists ($this->cacheBackend, 'expireAt') && isset($this->TTLInSeconds)) {
+        $this->cacheBackend->expireAt($key, time() + $this->TTLInSeconds);
+    }
   }
   
   public function get($latitude,$longitude)


### PR DESCRIPTION
Use CacheFrontEnd's setDefaultKeyTTL() method to define the default key Time to Live and as long as the provided cacheBackend has an expireAt() method it will be called whenever a key is set, to define the default TTL. (This is my first pull request ever, so I apologize in advance if anything is not up to standards)